### PR TITLE
Cache invalidation discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ $tardis = new Tardis\Factory::grow($apc);
 $slowRepository = new Repository\Country;
 $fastRepository = $tardis->cacheCallsFrom($slowRepository);
 
+// cache
 $brazil = $fastRepository->findByCode('BR');
+
+// invalidate
+$tardis->invalidate('findByCode', ['code' => 'BR']);
 ```
 
 Requirements: PHP >= 5.5

--- a/src/Computaria/Tardis/Factory.php
+++ b/src/Computaria/Tardis/Factory.php
@@ -2,7 +2,6 @@
 
 namespace Computaria\Tardis;
 
-use InvalidArgumentException;
 use Doctrine\Common\Cache\Cache;
 use ProxyManager\Factory as ProxyManager;
 use ProxyManager\Configuration as ProxyConfiguration;
@@ -21,7 +20,7 @@ class Factory
         $beforeMethodCall = new Interceptor\CacheFetch($cacheAdapter, $idGenerator);
         $afterMethodCall = new Interceptor\CacheSave($cacheAdapter, $idGenerator);
 
-        return new Proxy\PublicMethods($proxyFactory, $beforeMethodCall, $afterMethodCall);
+        return new Proxy\PublicMethods($proxyFactory, $beforeMethodCall, $afterMethodCall, $idGenerator, $cacheAdapter);
     }
 
     private static function createProxyFactoryIfNecessary(ProxyManager\AbstractBaseFactory $proxyFactory=null)

--- a/src/Computaria/Tardis/Tests/Functional/ArrayCacheTest.php
+++ b/src/Computaria/Tardis/Tests/Functional/ArrayCacheTest.php
@@ -125,4 +125,29 @@ class ArrayCacheTest extends \PHPUnit_Framework_TestCase
             'A public method proxy factory should be able to be created without and identity generator.'
         );
     }
+
+    /**
+     * @test
+     */
+    public function can_invalidate_cache()
+    {
+        $idGenerator = new Tardis\Identity\MethodCall();
+        $cacheId = $idGenerator->createIdFor('salute', ['name' => 'Impossible Girl']);
+        $tardis = Tardis\Factory::grow($this->cacheAdapter, $idGenerator, $this->proxyFactory);
+
+        $proxiedSubject = $tardis->cacheCallsFrom($this->subject);
+        $proxiedSubject->salute();
+
+        $this->assertTrue(
+            $this->cacheAdapter->contains($cacheId),
+            'Cache should contain a previous key.'
+        );
+
+        $tardis->invalidate('salute', ['name' => 'Impossible Girl']);
+
+        $this->assertFalse(
+            $this->cacheAdapter->contains($cacheId),
+            'Cache should invalidate key.'
+        );
+    }
 }

--- a/src/Computaria/Tardis/Tests/Unit/Proxy/PublicMethodsTest.php
+++ b/src/Computaria/Tardis/Tests/Unit/Proxy/PublicMethodsTest.php
@@ -23,6 +23,14 @@ class PublicMethodsTest extends \PHPUnit_Framework_TestCase
      */
     private $sufixIntercetor = null;
     /**
+     * @var \Computaria\Tardis\Identity\IdentityGenerator
+     */
+    private $identityGenerator = null;
+    /**
+     * @var \Doctrine\Common\Cache\Cache
+     */
+    private $cacheAdapter = null;
+    /**
      * @var \Computaria\Tardis\Proxy\PublicMethods
      */
     private $factory = null;
@@ -40,11 +48,15 @@ class PublicMethodsTest extends \PHPUnit_Framework_TestCase
         );
         $this->prefixInterceptor = $this->getMock('Computaria\\Tardis\\Interceptor\\PrefixInterceptor');
         $this->sufixIntercetor = $this->getMock('Computaria\\Tardis\\Interceptor\\SufixInterceptor');
+        $this->identityGenerator = $this->getMock('Computaria\\Tardis\\Identity\\IdentityGenerator');
+        $this->cacheAdapter = $this->getMock('Doctrine\\Common\\Cache\\Cache');
 
         $this->factory = new PublicMethods(
             $this->proxyFactory,
             $this->prefixInterceptor,
-            $this->sufixIntercetor
+            $this->sufixIntercetor,
+            $this->identityGenerator,
+            $this->cacheAdapter
         );
     }
 
@@ -64,5 +76,16 @@ class PublicMethodsTest extends \PHPUnit_Framework_TestCase
             );
 
         $proxiedInstance = $this->factory->cacheCallsFrom($realInstance);
+    }
+
+    /**
+     * @test
+     */
+    public function can_invalidate_cache()
+    {
+        $this->cacheAdapter->expects($this->once())
+            ->method('delete');
+
+        $this->factory->invalidate('salute', []);
     }
 }


### PR DESCRIPTION
## Progress
- [ ] Define an invalidation API. :construction_worker: 
- [ ] Implementation.
- [ ] Tests with all supported adapters (depending on the implementation, necessary if we do handle invalidation when storage does not support it already).
## Summary of discussion
1. First [PR](https://github.com/leocavalcante/Tardis/commit/f87991821f69b6bf2d6213009bb960a4129a9179) adds a `Tardis::invalidate($key, array $arguments)` method.
2. @augustohp [suggests](https://github.com/computeiros/Tardis/pull/4#issuecomment-126049043) for moving feature from **proxy factory** to **proxies** themselves.
3. @augustohp [suggests](https://github.com/computeiros/Tardis/pull/4#issuecomment-160338980) handling invalidation inside the **proxy factory** with a **TTL** implementation without exposing invalidation to developers using **proxied objects**.
